### PR TITLE
Bugfix radial gradient

### DIFF
--- a/GCanvas/core/src/GCanvas.cpp
+++ b/GCanvas/core/src/GCanvas.cpp
@@ -612,17 +612,6 @@ void GCanvas::execute2dCommands(const char *renderCommands, int length) {
                 p++;
                 char str[128];
                 float start[3], end[3];
-                // first triple define the `end` range
-                // second triple define the `start` range
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                end[0] = atoi(str);
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                end[1] = atoi(str);
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                end[2] = atoi(str);
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 start[0] = atoi(str);
@@ -632,6 +621,15 @@ void GCanvas::execute2dCommands(const char *renderCommands, int length) {
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 start[2] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                end[0] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                end[1] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                end[2] = atoi(str);
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 const int stop_count = atoi(str);

--- a/GCanvas/core/src/GCanvas.cpp
+++ b/GCanvas/core/src/GCanvas.cpp
@@ -612,15 +612,8 @@ void GCanvas::execute2dCommands(const char *renderCommands, int length) {
                 p++;
                 char str[128];
                 float start[3], end[3];
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                start[0] = atoi(str);
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                start[1] = atoi(str);
-                p = extractOneParameterFromCommand(str, p);
-                p++;
-                start[2] = atoi(str);
+                // first triple define the `end` range
+                // second triple define the `start` range
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 end[0] = atoi(str);
@@ -630,6 +623,15 @@ void GCanvas::execute2dCommands(const char *renderCommands, int length) {
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 end[2] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                start[0] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                start[1] = atoi(str);
+                p = extractOneParameterFromCommand(str, p);
+                p++;
+                start[2] = atoi(str);
                 p = extractOneParameterFromCommand(str, p);
                 p++;
                 const int stop_count = atoi(str);

--- a/GCanvas/core/src/gcanvas/GCanvas2dContext.cpp
+++ b/GCanvas/core/src/gcanvas/GCanvas2dContext.cpp
@@ -1263,17 +1263,25 @@ void GCanvasContext::LineTo(float x, float y) { mPath.LineTo(x, y); }
 
 void GCanvasContext::QuadraticCurveTo(float cpx, float cpy, float x, float y)
 {
-    float scale = mCurrentState->mTransform.a * mCurrentState->mTransform.a +
-                  mCurrentState->mTransform.d * mCurrentState->mTransform.d;
+    // mTranform is ProjectTransform, restore to trivial scale parameter.
+    float xscale = mCurrentState->mTransform.a * mWidth/(2.f * mDevicePixelRatio);
+    float scale = xscale;
+    float yscale = mCurrentState->mTransform.d * mHeight/(-2.f * mDevicePixelRatio);
+    if (yscale > scale) {
+        scale = yscale;
+    }
     mPath.QuadraticCurveTo(cpx, cpy, x, y, scale);
 }
 
 void GCanvasContext::BezierCurveTo(float cp1x, float cp1y, float cp2x,
                                     float cp2y, float x, float y)
 {
-    float scale = mCurrentState->mTransform.a * mCurrentState->mTransform.a +
-                  mCurrentState->mTransform.d * mCurrentState->mTransform.d;
-    scale = 1 / sqrtf(scale);
+    float xscale = mCurrentState->mTransform.a * mWidth/(2.f * mDevicePixelRatio);
+    float scale = xscale;
+    float yscale = mCurrentState->mTransform.d * mHeight/(-2.f * mDevicePixelRatio);
+    if (yscale > scale) {
+        scale = yscale;
+    }
     mPath.BezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y, scale);
 }
 
@@ -1430,8 +1438,7 @@ void GCanvasContext::UseLinearGradientPipeline()
             color[1] = stop->color.rgba.g;
             color[2] = stop->color.rgba.b;
             color[3] = stop->color.rgba.a;
-            mCurrentState->mShader->SetColorStop(color, i, stop->pos);
-        }
+            mCurrentState->mShader->SetColorStop(color, i, stop->pos);        }
     }
     if (mCurrentState != nullptr)
     {
@@ -1475,7 +1482,7 @@ void GCanvasContext::UseRadialGradientPipeline()
             color[1] = stop->color.rgba.g;
             color[2] = stop->color.rgba.b;
             color[3] = stop->color.rgba.a;
-            mCurrentState->mShader->SetColorStop(color, i, stop->pos);
+            mCurrentState->mShader->SetColorStop(color, i, stop->pos);            
         }
     }
     if (mCurrentState != nullptr)

--- a/GCanvas/core/src/gcanvas/GCanvas2dContext.cpp
+++ b/GCanvas/core/src/gcanvas/GCanvas2dContext.cpp
@@ -1457,7 +1457,7 @@ void GCanvasContext::UseRadialGradientPipeline()
 #ifdef ANDROID
     mCurrentState->mShader = mShaderManager->programForKey("RADIAL");
 #endif
-
+    
     if (mCurrentState->mShader != nullptr)
     {
         mCurrentState->mShader->Bind();
@@ -1466,23 +1466,25 @@ void GCanvasContext::UseRadialGradientPipeline()
         mCurrentState->mFillStyle->IsRadialGradient())
     {
         FillStyleRadialGradient *grad =
-            dynamic_cast< FillStyleRadialGradient * >(
-                mCurrentState->mFillStyle);
-        mCurrentState->mShader->SetRange(grad->GetStartPos(),
-                                         grad->GetEndPos());
+        dynamic_cast< FillStyleRadialGradient * >(
+                                                  mCurrentState->mFillStyle);
+        // first triple define the `end` range
+        // second triple define the `start` range
+        mCurrentState->mShader->SetRange(grad->GetEndPos(), grad->GetStartPos());
         mCurrentState->mShader->SetColorStopCount(grad->GetColorStopCount());
-
+        
         const int count = grad->GetColorStopCount();
         for (int i = 0; i < count; ++i)
         {
             const FillStyleRadialGradient::ColorStop *stop =
-                grad->GetColorStop(i);
+            grad->GetColorStop(i);
             float color[4];
             color[0] = stop->color.rgba.r;
             color[1] = stop->color.rgba.g;
             color[2] = stop->color.rgba.b;
             color[3] = stop->color.rgba.a;
-            mCurrentState->mShader->SetColorStop(color, i, stop->pos);            
+            // reverse the offset and index
+            mCurrentState->mShader->SetColorStop(color, count-1-i, 1-stop->pos);
         }
     }
     if (mCurrentState != nullptr)

--- a/GCanvas/core/src/gcanvas/GPath.h
+++ b/GCanvas/core/src/gcanvas/GPath.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 #define G_PATH_RECURSION_LIMIT 8
-#define G_PATH_DISTANCE_EPSILON 1.0f
+#define G_PATH_DISTANCE_EPSILON 0.5f
 #define G_PATH_COLLINEARITY_EPSILON FLT_EPSILON
 #define G_PATH_STEPS_FOR_CIRCLE 48.0f
 #define G_PATH_ANGLE_EPSILON = 0.01;
@@ -99,6 +99,9 @@ private:
     tSubPath mCurPath;
     std::vector<tSubPath> mPathStack;
     float mDistanceTolerance;
+#ifdef DEBUG
+    int mIterateCount;
+#endif
 };
 
 #endif

--- a/GCanvas/core/src/gcanvas/shaders/radiation.glsl
+++ b/GCanvas/core/src/gcanvas/shaders/radiation.glsl
@@ -34,70 +34,74 @@ uniform vec4      u_stop1;                                     \n\
 uniform vec4      u_stop2;                                     \n\
 uniform vec4      u_stop3;                                     \n\
 uniform vec4      u_stop4;                                     \n\
-void main()                                                                   \n\
-{                                                                             \n\
-   vec4 finalColor = vec4(1.0, 1.0, 1.0, 1.0);                                \n\
-   vec2 x_c0  = v_inPos - u_startPos.xy;                                      \n\
-   vec2 c1_c0 = u_endPos.xy - u_startPos.xy;                                  \n\
-   float t0 = dot(c1_c0, c1_c0) - u_endPos.z * u_endPos.z;                    \n\
-   float t1 = dot(x_c0, c1_c0) + u_startPos.z * u_endPos.z;                   \n\
-   float t2 = dot(x_c0, x_c0) - u_startPos.z * u_startPos.z;                  \n\
-   float t3 = t1 * t1 - t0 * t2;                                              \n\
-   float t4 = sqrt(t3) / t0;                                                  \n\
-   float t5 = t1 / t0;                                                        \n\
-   float t  = max(t4 + t5, t5 - t4);                                          \n\
-   if (u_startPos.z + t * u_endPos.z < 0.0) {                                 \n\
-   		gl_FragColor = vec4(finalColor.xyz, 1.0);                     \n\
-   }                                                                          \n\
-   else{                                                                      \n\
-                                                                              \n\
-           if (u_stopCount >= 1 && t < u_stop0.w) {                                   \n\
-   		finalColor = vec4(u_stop0.xyz, 1.0);                                  \n\
-           }                                                                          \n\
-           else if (u_stopCount >= 2 && u_stop0.w <= t && t <= u_stop1.w) {           \n\
-   		float w0 = t - u_stop0.w;                                             \n\
-   		float w1 = u_stop1.w - t;                                             \n\
-   		float w  = w0 + w1;                                                   \n\
-   		finalColor = u_stop0 * w1 / w + u_stop1 * w0 / w;                     \n\
-           }                                                                          \n\
-           else if (u_stopCount == 2 && u_stop1.w < t) {                              \n\
-   	        finalColor = u_stop1;                                                 \n\
-           }                                                                          \n\
-           else if (u_stopCount >= 3 && u_stop1.w <= t && t <= u_stop2.w) {           \n\
-   		float w0 = t - u_stop1.w;                                             \n\
-   		float w1 = u_stop2.w - t;                                             \n\
-   		float w  = w0 + w1;                                                   \n\
-   		finalColor = u_stop1 * w1 / w + u_stop2 * w0 / w;                     \n\
-           }                                                                          \n\
-           else if (u_stopCount == 3 && u_stop2.w < t) {                              \n\
-   		finalColor = u_stop2;                                                 \n\
-           }                                                                          \n\
-           else if (u_stopCount >= 4 && u_stop2.w <= t && t <= u_stop3.w) {           \n\
-   		float w0 = t - u_stop2.w;                                             \n\
-   		float w1 = u_stop3.w - t;                                             \n\
-   		float w  = w0 + w1;                                                   \n\
-   		finalColor = u_stop2 * w1 / w + u_stop3 * w0 / w;                     \n\
-           }                                                                          \n\
-           else if (u_stopCount == 4 && u_stop3.w < t) {                              \n\
-   		finalColor = u_stop3;                                                 \n\
-           }									      \n\
-           else if (u_stopCount >= 5 && u_stop3.w <= t && t <= u_stop4.w) {           \n\
-   		float w0 = t - u_stop3.w;                                             \n\
-   		float w1 = u_stop4.w - t;                                             \n\
-   		float w  = w0 + w1;                                                   \n\
-   		finalColor = u_stop3 * w1 / w + u_stop4 * w0 / w;                     \n\
-           }                                                                          \n\
-           else if (u_stopCount == 5 && u_stop4.w < t) {                              \n\
-   		finalColor = u_stop4;                                                 \n\
-           }									      \n\
-           if (b_hasTexture) {                                                        \n\
-                vec4 marsk = texture2D(u_texture, v_texCoord);                        \n\
-                gl_FragColor = vec4(finalColor.xyz, marsk.w);                         \n\
-           }                                                                          \n\
-           else {                                                                     \n\
-   		gl_FragColor = vec4(finalColor.xyz, 1.0); 			      \n\
-           }                                                                          \n\
-    }                                                                                 \n\
+uniform float      u_colorStop0;                               \n\
+uniform float      u_colorStop1;                               \n\
+uniform float      u_colorStop2;                               \n\
+uniform float      u_colorStop3;                               \n\
+uniform float      u_colorStop4;                               \n\
+void main()                                                                    \n\
+{                                                                              \n\
+    vec4 finalColor = vec4(1.0, 1.0, 1.0, 1.0);                                \n\
+    vec2 x_c0  = v_inPos - u_startPos.xy;                                      \n\
+    vec2 c1_c0 = u_endPos.xy - u_startPos.xy;                                  \n\
+    float t0 = dot(c1_c0, c1_c0) - u_endPos.z * u_endPos.z;                    \n\
+    float t1 = dot(x_c0, c1_c0) + u_startPos.z * u_endPos.z;                   \n\
+    float t2 = dot(x_c0, x_c0) - u_startPos.z * u_startPos.z;                  \n\
+    float t3 = t1 * t1 - t0 * t2;                                              \n\
+    float t4 = sqrt(t3) / t0;                                                  \n\
+    float t5 = t1 / t0;                                                        \n\
+    float t  = max(t4 + t5, t5 - t4);                                          \n\
+    if (u_startPos.z + t * u_endPos.z < 0.0) {                                 \n\
+   		gl_FragColor = vec4(finalColor.xyz, 1.0);                              \n\
+    }                                                                          \n\
+    else{                                                                      \n\
+        if (u_stopCount >= 1 && t < u_colorStop0) {                            \n\
+   		    finalColor = vec4(u_stop0.xyz, 1.0);                               \n\
+        }                                                                      \n\
+        else if (u_stopCount >= 2 && u_colorStop0 <= t && t <= u_colorStop1) { \n\
+   		    float w0 = t - u_colorStop0;                                       \n\
+   		    float w1 = u_colorStop1 - t;                                       \n\
+   		    float w  = w0 + w1;                                                \n\
+   		    finalColor = u_stop0 * w1 / w + u_stop1 * w0 / w;                  \n\
+        }                                                                      \n\
+        else if (u_stopCount == 2 && u_colorStop1 < t) {                       \n\
+   	        finalColor = u_stop1;                                              \n\
+        }                                                                      \n\
+        else if (u_stopCount >= 3 && u_colorStop1 <= t && t <= u_colorStop2) { \n\
+   		    float w0 = t - u_colorStop1;                                       \n\
+   		    float w1 = u_colorStop2 - t;                                       \n\
+   		    float w  = w0 + w1;                                                \n\
+   		    finalColor = u_stop1 * w1 / w + u_stop2 * w0 / w;                  \n\
+        }                                                                      \n\
+        else if (u_stopCount == 3 && u_colorStop2 < t) {                       \n\
+   		    finalColor = u_stop2;                                              \n\
+        }                                                                      \n\
+        else if (u_stopCount >= 4 && u_colorStop2 <= t && t <= u_colorStop3) { \n\
+   		    float w0 = t - u_colorStop2;                                       \n\
+   		    float w1 = u_colorStop3 - t;                                       \n\
+   		    float w  = w0 + w1;                                                \n\
+   		    finalColor = u_stop2 * w1 / w + u_stop3 * w0 / w;                  \n\
+        }                                                                      \n\
+        else if (u_stopCount == 4 && u_colorStop3 < t) {                       \n\
+   		    finalColor = u_stop3;                                              \n\
+        }									      \n\
+        else if (u_stopCount >= 5 && u_colorStop3 <= t && t <= u_colorStop4) { \n\
+   		    float w0 = t - u_colorStop3;                                       \n\
+   		    float w1 = u_colorStop4 - t;                                       \n\
+   		    float w  = w0 + w1;                                                \n\
+   		    finalColor = u_stop3 * w1 / w + u_stop4 * w0 / w;                  \n\
+        }                                                                      \n\
+        else if (u_stopCount == 5 && u_colorStop4 < t) {                       \n\
+   		    finalColor = u_stop4;                                              \n\
+        }									                                   \n\
+        if (b_hasTexture) {                                                    \n\
+            vec4 marsk = texture2D(u_texture, v_texCoord);                     \n\
+            gl_FragColor = vec4(finalColor.xyz, marsk.w);                      \n\
+        }                                                                      \n\
+        else {                                                                 \n\
+   		    gl_FragColor = vec4(finalColor.xyz, 1.0); 			               \n\
+        }                                                                      \n\
+    }                                                                          \n\
 }"
 
 


### PR DESCRIPTION
1. fixed radiation.glsl, read u_colorStop* correctly
2. fixed createLinearGradient parameter parser, first triple was defined as `stop` position, and second triple was defined as `start` position witch in accord with canvas standard definition.